### PR TITLE
Change readme to be about the worst evictors site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is based on a [Gatsby starter](https://github.com/fhavrlent/gatsby-contentful
 
 1. **Set Contentful API keys.**
 
-  Copy **`.env.sample`** to **`.env`** and set your Contentful API variables.
+  Copy **`.env.sample`** to **`.env`** and set your Contentful API variables. This will require you to make an account with [Contentful](https://www.contentful.com/). 
 
 2. **Install dependencies.**
 
@@ -24,7 +24,7 @@ It is based on a [Gatsby starter](https://github.com/fhavrlent/gatsby-contentful
 
 3. **Start developing.**
 
-  Run `yarn develop` to start developing.
+  Run `gatsby develop` to start developing.
 
   Your site is now running at `http://localhost:8000`!
 

--- a/README.md
+++ b/README.md
@@ -4,118 +4,32 @@
   </a>
 </p>
 <h1 align="center">
-  Gatsby Contentful TypeScript starter 
+  Right To Counsel NYC Coalition's Worst Evictors Website
 </h1>
 
-Gatsby starter with Contentful and TypeScript configuration.
+This repository contains the Right To Counsel (RTC) NYC Coalition's Worst Evictors Website.
+
+It is based on a [Gatsby starter](https://github.com/fhavrlent/gatsby-contentful-typescript-starter). Almost all of the content is pulled from [Contentful](https://www.contentful.com/).
 
 
 ## 🚀 Quick start
 
-1.  **Install the Gatsby CLI.**
+1. **Set Contentful API keys.**
 
-    The Gatsby CLI helps you create new sites using Gatsby starters (like this one!)
+  Copy **`.env.sample`** to **`.env`** and set your Contentful API variables.
 
-    ```sh
-    # install the Gatsby CLI globally
-    npm install -g gatsby-cli
-    ```
+2. **Install dependencies.**
 
-2.  **Create a Gatsby site.**
+  Run `yarn` to install all dependencies.
 
-    Use the Gatsby CLI to create a new site, specifying the default starter.
+3. **Start developing.**
 
-    ```sh
-    # create a new Gatsby site using the default starter
-    gatsby new my-project https://github.com/fhavrlent/gatsby-contentful-typescript-starter
-    ```
+  Run `yarn develop` to start developing.
 
-3. **Set Contentful API keys.**
+  Your site is now running at `http://localhost:8000`!
 
-    Rename **`empty.env`** to **`.env`** and set your Contentful API variables
+  *Note: You'll also see a second link: `http://localhost:8000___graphql`. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://next.gatsbyjs.org/tutorial/part-five/#introducing-graphiql).*
 
-3.  **Start developing.**
+4. **Edit some files!**
 
-    Navigate into your new site’s directory and start it up.
-
-    ```sh
-    cd my-default-starter/
-    npm develop
-    ```
-
-4.  **Open the source code and start editing!**
-
-    Your site is now running at `http://localhost:8000`!
-    
-    *Note: You'll also see a second link: `http://localhost:8000___graphql`. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://next.gatsbyjs.org/tutorial/part-five/#introducing-graphiql).*
-    
-    Open the the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
-    
-## 🧐 What's inside?
-
-A quick look at the top-level files and directories you'll see in a Gatsby project.
-
-    .
-    ├── node_modules
-    ├── src
-    ├── .gitignore
-    ├── .nvmrc
-    ├── .prettierrc
-    ├── empty.env
-    ├── gatsby-browser.js
-    ├── gatsby-config.js
-    ├── gatsby-node.js
-    ├── gatsby-ssr.js
-    ├── LICENSE
-    ├── package-lock.json
-    ├── package.json
-    ├── README.md
-    ├── tsconfig.json
-    ├── tslint.json
-    └── yarn.lock
-
-  1.  **`/node_modules`**: The directory where all of the modules of code that your project depends on (npm packages) are automatically installed.  
-  
-  2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser), like your site header, or a page template. “Src” is a convention for “source code”.
-  
-  3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
-  
-  4. **`.nvmrc`**: NVM configuration so packages works as they should
-
-  5.  **`.prettierrc`**: This is a configuration file for a tool called [Prettier](https://prettier.io/), which is a tool to help keep the formatting of your code consistent.
-
-  6. **`empty.env`**: Rename to **`.env`** and set your Contentful API key
-  
-  7.  **`gatsby-browser.tsx`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://next.gatsbyjs.org/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
-  
-  6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://next.gatsbyjs.org/docs/gatsby-config/) for more detail).
-  
-  8.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby node APIs](https://next.gatsbyjs.org/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
-  
-  9.  **`gatsby-ssr.tsx`**: This file is where Gatsby expects to find any usage of the [Gatsby server-side rendering APIs](https://next.gatsbyjs.org/docs/ssr-apis/) (if any). These allow customization of default Gatsby settings affecting server-side rendering.
-  
-  910.  **`LICENSE`**: Gatsby is licensed under the MIT license.
-  
-  11.  **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. (You won’t change this file directly).
-  
-  12.  **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
-  
-  13.  **`README.md`**: A text file containing useful reference information about your project.
-
-  14.  **`tsconfig.json`**: Config file for TypeScript
-
-  15.  **`tslint.json`**: TS Lint configuration file
-  
-  16.  **`yarn.lock`**: [Yarn](https://yarnpkg.com/) is a package manager alternative to npm. You can use either yarn or npm, though all of the Gatsby docs reference npm.  This file serves essentially the same purpose as `package-lock.json`, just for a different package management system.
-
-## 🎓 Learning Gatsby
-
-Looking for more guidance? Full documentation for Gatsby lives [on the website](https://next.gatsbyjs.org/). Here are some places to start:
-
--   **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
-
--   **To dive straight into code samples head [to our documentation](https://next.gatsbyjs.org/docs/).** In particular, check out the “Guides”, API reference, and “Advanced Tutorials” sections in the sidebar.
-
-## 💫 Deploy
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/fhavrlent/gatsby-contentful-typescript-starter)
+  Open the the repository's root directory in your code editor of choice and edit `src/pages/index.tsx`. Save your changes and the browser will update in real time!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is based on a [Gatsby starter](https://github.com/fhavrlent/gatsby-contentful
 
 1. **Set Contentful API keys.**
 
-  Copy **`.env.sample`** to **`.env`** and set your Contentful API variables. This will require you to make an account with [Contentful](https://www.contentful.com/). 
+  Copy **`.env.sample`** to **`.env`** and set your Contentful API variables. To grab these variables, make an account and create a content space with [Contentful](https://www.contentful.com/). 
 
 2. **Install dependencies.**
 
@@ -24,7 +24,7 @@ It is based on a [Gatsby starter](https://github.com/fhavrlent/gatsby-contentful
 
 3. **Start developing.**
 
-  Run `gatsby develop` to start developing.
+  Run `yarn develop` to start developing.
 
   Your site is now running at `http://localhost:8000`!
 


### PR DESCRIPTION
This replaces the default Gatsby starter readme with content that is more appropriate for this project.

I'd like to have a "deploy" section in here but I'm not actually sure how this site is deployed... is it through netlify like the EFNYC site?
