### PR TITLE
Create devcontainer.json to configure VSCode within Docker container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-dockerfile
+{
+    "name": "Worst Evictors Site VSCode development container",
+    "image": "node:12",
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": null,
+        // This is where the virtual environment set up by our Docker Compose config is located.
+        "[typescriptreact]": {
+            "editor.tabSize": 2,
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[typescript]": {
+            "editor.tabSize": 2,
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[json]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[javascript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+    },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+    ],
+    "mounts": [
+        // These mounts will ensure that the volumes our Docker Compose setup uses
+        // (see `docker-compose.yml`) will be reused by VSCode.  Note that these
+        // rely on the project to be cloned in a folder called `justfix-website`, since
+        // Docker Compose prefixes the volumes it creates with this directory name.
+        "source=worst-evictors-site_node-modules,target=/workspaces/worst-evictors-site/node_modules/,type=volume"
+    ],
+}


### PR DESCRIPTION
This PR simply adds the same devcontainer configuration file that the JustFix tenant platform uses, so that we can start writing code in VSCode within the Docker container locally. 