### PR TITLE
Link directly to evictors section from list page

### DIFF
--- a/src/components/evictor.tsx
+++ b/src/components/evictor.tsx
@@ -187,7 +187,7 @@ const EvictorProfile: React.FC<EvictorProps> = ({ content }) => (
             contentfulOptions
           )}
         <br />
-        <Link to="/" className="btn btn-primary">
+        <Link to="/#evictors" className="btn btn-primary">
           Back to worst evictors list
         </Link>
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -154,6 +154,7 @@ const LandingPage = () => (
                 <div className="columns">
                   <div
                     key="e-intro"
+                    id="evictors"
                     className="column col-3 col-xl-4 col-lg-12 bg-primary text-right fade-in-0"
                   >
                     <span aria-hidden>

--- a/src/pages/list.tsx
+++ b/src/pages/list.tsx
@@ -107,7 +107,7 @@ const CitywideEvictorsListPage = () => (
                     contentfulOptions
                   )}
                   <br />
-                  <Link to="/" className="btn btn-primary">
+                  <Link to="/#evictors" className="btn btn-primary">
                     Back to worst evictors list
                   </Link>
                 </div>


### PR DESCRIPTION
This PR makes sure that on mobile devices, when a user navigates back to the worst evictors via a button from the list page, that they appear back at the top of the list of evictor icons.