### PR TITLE
Replace all instances of JustFix.nyc with JustFix.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Then visit `http://localhost:8000`!
   
 ## Code of Conduct
 
-  Read about JustFix's code of conduct as an organization on our [Mission page](https://www.justfix.nyc/our-mission/).
+  Read about JustFix's code of conduct as an organization on our [Mission page](https://www.justfix.org/our-mission/).

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -54,7 +54,7 @@ const Footer = () => (
         />
       </div>
       Made with NYC ♥ by the team at{" "}
-      <OutboundLink href="https://justfix.nyc">JustFix</OutboundLink> and the{" "}
+      <OutboundLink href="https://justfix.org">JustFix</OutboundLink> and the{" "}
       <span className="nobr">
         <OutboundLink href="https://antievictionmap.com/">
           Anti&#8209;Eviction Mapping Project

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -59,7 +59,7 @@ const Layout = ({
         />
         <meta
           name="author"
-          content="Right to Counsel Coalition, JustFix.nyc, and the Anti-Eviction Mapping Project"
+          content="Right to Counsel Coalition, JustFix, and the Anti-Eviction Mapping Project"
         />
 
         <meta property="fb:app_id" content="247990609143668" />


### PR DESCRIPTION
This PR changes all urls and labels from our old org name to our new one. Specifically it:

- updates any name of our organization from JustFix.nyc to JustFix
- updates any url references from justfix.nyc/... to justfix.org/...
- updates any of our email addresses from @justfix.nyc to @justfix.org

NOTE: we may want to update our Contentful content with any links that link out to a justfix.nyc domain (I just checked and there aren't many), however this is not a huge priority since the redirects should still work.