### PR TITLE
Remove mobile CSS rules for map view

### DIFF
--- a/src/styles/map.scss
+++ b/src/styles/map.scss
@@ -38,6 +38,14 @@ $bottom-banner-height: 40px;
   width: 100%;
   height: calc(100vh - #{$title-banner-height} - #{$bottom-banner-height});
   background-color: $carto-background;
+
+  // make sure map doesn't overlap with Menu button on mobile:
+  @include for-carto-map-minimized() {
+    padding: 7px;
+    height: calc(
+      100vh - #{$title-banner-height} - #{$bottom-banner-height} - 100px
+    );
+  }
 }
 
 .map-bottom-banner {

--- a/src/styles/map.scss
+++ b/src/styles/map.scss
@@ -43,7 +43,7 @@ $bottom-banner-height: 40px;
   @include for-carto-map-minimized() {
     padding: 7px;
     height: calc(
-      100vh - #{$title-banner-height} - #{$bottom-banner-height} - 100px
+      100vh - #{$title-banner-height} - #{$bottom-banner-height} - 150px
     );
   }
 }

--- a/src/styles/map.scss
+++ b/src/styles/map.scss
@@ -38,15 +38,6 @@ $bottom-banner-height: 40px;
   width: 100%;
   height: calc(100vh - #{$title-banner-height} - #{$bottom-banner-height});
   background-color: $carto-background;
-
-  // remove Landlord widget by bringing margin up to cover it
-  @include for-carto-map-minimized() {
-    padding: 7px;
-    height: calc(
-      100vh - #{$title-banner-height} - #{$bottom-banner-height} + 210px
-    );
-    margin-bottom: -210px;
-  }
 }
 
 .map-bottom-banner {


### PR DESCRIPTION
This PR fixes a bug where the user had no way to close the map widget on mobile devices and therefore couldn't see the main map view. 